### PR TITLE
Add CSS parser for template preview styles

### DIFF
--- a/components/TemplatesPanel.tsx
+++ b/components/TemplatesPanel.tsx
@@ -317,7 +317,7 @@ const TemplatesPanel: React.FC = () => {
             <h1 class="edu-title">عنوان الدرس</h1>
             <ul class="edu-points">
               <li style="--delay: 0s">النقطة الأولى المهمة</li>
-              <li style="--delay: 0.2s">النقطة الثانية</li>
+              <li style="--delay: 0.2s">النقطة ا��ثانية</li>
               <li style="--delay: 0.4s">النقطة الثالثة</li>
               <li style="--delay: 0.6s">الخلاصة والتطبيق</li>
             </ul>
@@ -542,8 +542,8 @@ const TemplatesPanel: React.FC = () => {
             >
               {/* Preview */}
               <div
-                className="h-48 relative overflow-hidden"
-                style={{ background: template.previewCode }}
+                className="h-48 relative overflow-hidden preview-background"
+                style={getPreviewStyle(template.previewCode)}
               >
                 <div className="absolute inset-0 flex items-center justify-center">
                   <div className="text-white text-center">

--- a/components/TemplatesPanel.tsx
+++ b/components/TemplatesPanel.tsx
@@ -142,7 +142,8 @@ const TemplatesPanel: React.FC = () => {
           </div>
         </div>
       `,
-      previewCode: "text-shadow: 0 0 20px #00ff88; border: 2px solid #00ff88;",
+      previewCode:
+        "background: #0a0a0a; color: #00ff88; text-shadow: 0 0 20px #00ff88",
     },
     {
       id: "minimalist-outro-1",

--- a/components/TemplatesPanel.tsx
+++ b/components/TemplatesPanel.tsx
@@ -25,6 +25,27 @@ const TemplatesPanel: React.FC = () => {
   );
   const [showPreview, setShowPreview] = useState(false);
 
+  // Helper function to convert CSS string to React style object
+  const getPreviewStyle = (cssString: string): React.CSSProperties => {
+    const styles: React.CSSProperties = {};
+
+    // Split by semicolon and parse each property
+    const declarations = cssString.split(";").filter((d) => d.trim());
+
+    declarations.forEach((declaration) => {
+      const [property, value] = declaration.split(":").map((s) => s.trim());
+      if (property && value) {
+        // Convert kebab-case to camelCase for React
+        const camelCaseProperty = property.replace(/-([a-z])/g, (g) =>
+          g[1].toUpperCase(),
+        );
+        styles[camelCaseProperty as keyof React.CSSProperties] = value;
+      }
+    });
+
+    return styles;
+  };
+
   // قوالب CSS/HTML حقيقية وفعالة
   const realTemplates: RealTemplate[] = [
     {
@@ -317,7 +338,7 @@ const TemplatesPanel: React.FC = () => {
             <h1 class="edu-title">عنوان الدرس</h1>
             <ul class="edu-points">
               <li style="--delay: 0s">النقطة الأولى المهمة</li>
-              <li style="--delay: 0.2s">النقطة ا��ثانية</li>
+              <li style="--delay: 0.2s">النقطة الثانية</li>
               <li style="--delay: 0.4s">النقطة الثالثة</li>
               <li style="--delay: 0.6s">الخلاصة والتطبيق</li>
             </ul>


### PR DESCRIPTION
Add helper function `getPreviewStyle` to convert CSS strings to React style objects.

Changes:
- Add `getPreviewStyle` function that parses CSS declarations and converts kebab-case properties to camelCase
- Update template preview rendering to use the new parser function instead of direct CSS string
- Modify preview code for "cyberpunk-outro-1" template to include background and color properties
- Replace direct style assignment with parsed style object in template preview div

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 7`

🔗 [Edit in Builder.io](https://builder.io/app/projects/6edccbb3611e447b8fd9bc52a8234b5a/pulse-landing)

👀 [Preview Link](https://6edccbb3611e447b8fd9bc52a8234b5a-pulse-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>6edccbb3611e447b8fd9bc52a8234b5a</projectId>-->
<!--<branchName>pulse-landing</branchName>-->